### PR TITLE
Upgrade `tech.ml.dataset` and Tablecloth to v7.014

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,17 +3,19 @@
   :url "https://clojure-finance.github.io/datajure-website/"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.apache.arrow/arrow-memory-unsafe "2.0.0"]
                  [org.apache.arrow/arrow-memory-core "2.0.0"]
                  [org.apache.arrow/arrow-vector "2.0.0" :exclusions [commons-codec]]
-                 [techascent/tech.ml.dataset "6.104"]
-                 [scicloj/tablecloth "6.103.1"]
+                 [techascent/tech.ml.dataset "7.014"]
+                 [scicloj/tablecloth "7.014"]
                  [com.github.clojure-finance/clojask "2.0.0"]
                  [org.clojure/algo.generic "0.1.3"]
                  [zero.one/geni "0.0.40"]
                  [com.fasterxml.jackson.core/jackson-core "2.15.2"]
-                 [metrics-clojure "2.10.0"]]
+                 [metrics-clojure "2.10.0"]
+                 [org.apache.poi/poi "5.2.3"]
+                 [org.apache.poi/poi-ooxml "5.2.3"]]
   :main ^:skip-aot datajure.dsl
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all

--- a/project.clj
+++ b/project.clj
@@ -4,39 +4,19 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.apache.arrow/arrow-memory-unsafe "2.0.0"]
-                 [org.apache.arrow/arrow-memory-core "2.0.0"]
-                 [org.apache.arrow/arrow-vector "2.0.0" :exclusions [commons-codec]]
                  [techascent/tech.ml.dataset "7.014"]
                  [scicloj/tablecloth "7.014"]
                  [com.github.clojure-finance/clojask "2.0.0"]
-                 [org.clojure/algo.generic "0.1.3"]
                  [zero.one/geni "0.0.40"]
                  [com.fasterxml.jackson.core/jackson-core "2.15.2"]
                  [metrics-clojure "2.10.0"]
-                 [org.apache.poi/poi "5.2.3"]
-                 [org.apache.poi/poi-ooxml "5.2.3"]]
+                 [org.apache.poi/poi "5.2.3"]]
   :main ^:skip-aot datajure.dsl
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}
-             :provided {:dependencies [;; Spark
-                                       [org.apache.spark/spark-avro_2.12 "3.1.1"]
-                                       [org.apache.spark/spark-core_2.12 "3.1.1"]
-                                       [org.apache.spark/spark-hive_2.12 "3.1.1"]
+             :provided {:dependencies [[org.apache.spark/spark-core_2.12 "3.1.1"]
                                        [org.apache.spark/spark-mllib_2.12 "3.1.1"]
                                        [org.apache.spark/spark-sql_2.12 "3.1.1"]
-                                       [org.apache.spark/spark-streaming_2.12 "3.1.1"]
-                                       [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
-                                       ;; Arrow
-                                       [org.apache.arrow/arrow-memory-netty "2.0.0"]
-                                       [org.apache.arrow/arrow-memory-core "2.0.0"]
                                        [org.apache.arrow/arrow-vector "2.0.0"
-                                        :exclusions [commons-codec com.fasterxml.jackson.core/jackson-databind]]
-                                       ;; Databases
-                                       [mysql/mysql-connector-java "8.0.23"]
-                                       [org.postgresql/postgresql "42.2.19"]
-                                       [org.xerial/sqlite-jdbc "3.34.0"]
-                                       ;; Optional: Spark XGBoost
-                                       [ml.dmlc/xgboost4j-spark_2.12 "1.2.0"]
-                                       [ml.dmlc/xgboost4j_2.12 "1.2.0"]]}})
+                                        :exclusions [commons-codec com.fasterxml.jackson.core/jackson-databind]]]}})

--- a/src/datajure/dsl.clj
+++ b/src/datajure/dsl.clj
@@ -1,4 +1,5 @@
-(ns datajure.dsl)
+(ns datajure.dsl
+  (:refer-clojure :exclude [print]))
 
 (require '[tech.v3.dataset :as ds]
          '[tablecloth.api :as tc]


### PR DESCRIPTION
- Closes #19
  - See #12 for details
- Closes #22
- Remove unused dependencies from `project.clj`
- Exclude built-in function `print` to avoid the warning on naming conflict