### PR TITLE
Bump up version to v1.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.clojure-finance/datajure "1.0.0"
+(defproject com.github.clojure-finance/datajure "1.0.1"
   :description "An open-source domain-specific language for data processing."
   :url "https://clojure-finance.github.io/datajure-website/"
   :license {:name "The MIT License"


### PR DESCRIPTION
- No substantial updates
- In order to modify the repo address on Clojars, a new version number is required