### PR TITLE
Upgrade Clojure to v1.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [techascent/tech.ml.dataset "7.020"]
                  [scicloj/tablecloth "7.014"]
                  [com.github.clojure-finance/clojask "2.0.2"]
-                 [zero.one/geni "0.0.41"]
+                 [zero.one/geni "0.0.42"]
                  [com.fasterxml.jackson.core/jackson-core "2.15.3"]
                  [metrics-clojure "2.10.0"]
                  [org.apache.poi/poi "5.2.4"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://clojure-finance.github.io/datajure-website/"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [techascent/tech.ml.dataset "7.020"]
                  [scicloj/tablecloth "7.014"]
                  [com.github.clojure-finance/clojask "2.0.2"]


### PR DESCRIPTION
- Upgrades Geni to v0.0.42
- Upgrades Clojure to v1.11.1
- Closes #16