### PR TITLE
Add tests for REPL and Leiningen template

### DIFF
--- a/.github/scripts/test-datajure-repl
+++ b/.github/scripts/test-datajure-repl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+wget https://raw.githubusercontent.com/clojure-finance/datajure/main/scripts/datajure
+chmod +x datajure
+exit | ./datajure

--- a/.github/scripts/test-lein-template
+++ b/.github/scripts/test-lein-template
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd lein-template
+lein new com.github.clojure-finance/datajure myproject
+cd myproject
+exit | lein run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Run tests
         run: lein test
+
+      - name: Test Leiningen template
+        run: chmod +x ./.github/scripts/test-lein-template && ./.github/scripts/test-lein-template
+
+      - name: Test Datajure REPL
+        run: chmod +x ./.github/scripts/test-datajure-repl && ./.github/scripts/test-datajure-repl


### PR DESCRIPTION
- Closes #48
- For Datajure REPL, we only test the normal functioning of the launcher without actually performing a test of the data processing functionality as it is already tested in the `lein test`. The correctness of REPL is guaranteed by REPL-y and nREPL and does not need to be tested in this project.