### PR TITLE
Refactor and optimize

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
                  [org.apache.spark/spark-sql_2.12 "3.3.3"]
                  [org.apache.spark/spark-streaming_2.12 "3.3.3"]]
   :main ^:skip-aot datajure.dsl
+  :plugins [[dev.weavejester/lein-cljfmt "0.12.0"]]
   :target-path "target/%s"
   :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
              "--add-opens=java.base/java.net=ALL-UNNAMED"

--- a/src/datajure/dsl.clj
+++ b/src/datajure/dsl.clj
@@ -1,5 +1,5 @@
 (ns datajure.dsl
-  (:refer-clojure :exclude [print]) 
+  (:refer-clojure :exclude [print])
   (:require [datajure.repl :as repl])
   (:gen-class))
 
@@ -99,14 +99,13 @@
                           (filterv #(= 3 (count %))))
          group-by-list (:group-by options-map)
          sort-by-list (:sort-by options-map)
-
          query-map {:row row-list
                     :where where-list
                     :group-by group-by-list
                     :having having-list
                     :sort-by sort-by-list
                     :select select-list}]
-    `(query-using-map ~dataset ~query-map)))
+     `(query-using-map ~dataset ~query-map)))
   ([dataset row-filter-list select-list]
    `(query ~dataset ~row-filter-list ~select-list [])))
 

--- a/src/datajure/operation_ck.clj
+++ b/src/datajure/operation_ck.clj
@@ -1,5 +1,5 @@
 (ns datajure.operation-ck
-  (:refer-clojure :exclude [group-by sort-by]) 
+  (:refer-clojure :exclude [group-by sort-by])
   (:require [clojure.java.io :refer [make-parents]]
             [clojask.dataframe :as ck]))
 
@@ -228,7 +228,7 @@
   "Select columns of `dataset` according to `query-map`."
   [dataset query-map]
   (let [select-all-keys (split-col-agg-keys-r dataset (:select query-map))]
-     (if (empty? select-all-keys)
-       (ck/compute dataset 8 "./.dsl/select-result.csv")
-       (ck/compute dataset 8 "./.dsl/select-result.csv" :select select-all-keys)))
+    (if (empty? select-all-keys)
+      (ck/compute dataset 8 "./.dsl/select-result.csv")
+      (ck/compute dataset 8 "./.dsl/select-result.csv" :select select-all-keys)))
   dataset)

--- a/src/datajure/operation_ds.clj
+++ b/src/datajure/operation_ds.clj
@@ -4,7 +4,6 @@
 (require '[tech.v3.dataset :as ds]
          '[tech.v3.dataset.join :as ds-join])
 
-
 (def ^:private aggregate-function-keywords #{:min :mean :mode :max :sum :sd :skew :n-valid :n-missing :n})
 
 (defn- filter-column-r
@@ -52,8 +51,6 @@
         list-num-missing (descriptive-ds :n-missing)
         list-num-total (mapv #(+ %1 %2) list-num-missing list-num-valid)
         list-sum (mapv #(if (and (number? %1) (number? %2)) (* %1 %2) nil) list-mean list-num-valid)
-
-
         min-keys (mapv #(get-key-val %1 %2 :min) list-col list-min)
         mean-keys (mapv #(get-key-val %1 %2 :mean) list-col list-mean)
         mode-keys (mapv #(get-key-val %1 %2 :mode) list-col list-mode)
@@ -79,7 +76,6 @@
           agg-ds (apply ds/concat (vals descriptive-grouped-map))]
       (ds-join/left-join group-by-col first-ds agg-ds))))
 
-
 (defn- get-combined-group-by-col
   "Get the combined form of column names as described by `group-by-col`."
   [group-by-col]
@@ -96,15 +92,13 @@
   (let [group-by-col (get query-map :group-by)]
     (if (nil? group-by-col)
       dataset
-      (if (or (seq? group-by-col) (list? group-by-col) (vector? group-by-col))
-        (if (empty? group-by-col)
-          dataset
-          (if (= 1 (count group-by-col))
-            (group-by-single dataset (first group-by-col))
-            (let [new-col (get-combined-group-by-col group-by-col)
-                  new-dataset (assoc dataset new-col (get-combined-group-by-val dataset group-by-col))]
-              (group-by-single new-dataset new-col))))
-        (group-by-single dataset group-by-col)))))
+      (if (empty? group-by-col)
+        dataset
+        (if (= 1 (count group-by-col))
+          (group-by-single dataset (first group-by-col))
+          (let [new-col (get-combined-group-by-col group-by-col)
+                new-dataset (assoc dataset new-col (get-combined-group-by-val dataset group-by-col))]
+            (group-by-single new-dataset new-col)))))))
 
 (defn having
   "Perform the `HAVING` operation on `dataset` by specifying a search condition for a group or an aggregate according to `query-map`."
@@ -130,7 +124,6 @@
           (if (nil? compare-fn)
             (ds/sort-by-column dataset colname)
             (ds/sort-by-column dataset colname compare-fn)))))))
-
 
 (defn- split-col-agg-keys-r
   "Convert aggregation keywords in `mixed-words` from separated form to combined form."

--- a/src/datajure/operation_g.clj
+++ b/src/datajure/operation_g.clj
@@ -72,7 +72,6 @@
                           (get-agg-key first-exp :first)))]
           (g/sort dataset colname))))))
 
-
 (defn- split-col-agg-keys-r
   "Convert aggregation keywords in `mixed-words` from separated form to combined form."
   [mixed-words]

--- a/test/datajure/dsl_test.clj
+++ b/test/datajure/dsl_test.clj
@@ -48,29 +48,29 @@
   (let [expected (slurp "./test/datajure/tc-expected.txt")
         actual (with-out-str (do (dtj/set-backend "tablecloth")
                                  (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:salary #(< 300 %)] [:age #(> 20 %)]] [])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:sum :salary #(< 1000 %)]] [:age :sum :salary] [:group-by :age])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [] [:age :sum :salary :sd :salary] [:group-by :age :sort-by :sd :salary >])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [] [:age :name :sum :salary] [:group-by :age :name])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:salary #(< 0 %)] [:age #(< 24 %)]] [])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:sum :salary #(< 0 %)] [:age #(< 0 %)]] [:name :age :salary :sum :salary :sd :salary] [:group-by :name :age :sort-by :salary])
-                                        (dtj/print))))]
+                                     (dtj/dataset)
+                                     (dtj/query [[:salary #(< 300 %)] [:age #(> 20 %)]] [])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:sum :salary #(< 1000 %)]] [:age :sum :salary] [:group-by :age])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [] [:age :sum :salary :sd :salary] [:group-by :age :sort-by :sd :salary >])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [] [:age :name :sum :salary] [:group-by :age :name])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:salary #(< 0 %)] [:age #(< 24 %)]] [])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:sum :salary #(< 0 %)] [:age #(< 0 %)]] [:name :age :salary :sum :salary :sd :salary] [:group-by :name :age :sort-by :salary])
+                                     (dtj/print))))]
     (is (check actual expected) actual)))
 
 (deftest ck-test
@@ -104,27 +104,27 @@
   (let [expected (slurp "./test/datajure/g-expected.txt")
         actual (with-out-str (do (dtj/set-backend "geni")
                                  (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:salary (g/< (g/lit 300) :salary)] [:age (g/> (g/lit 20) :age)]] [])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:sum :salary (g/< (g/lit 1000) (keyword "sum(salary)"))]] [:age :sum :salary] [:group-by :age])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [] [:age :sum :salary :sd :salary] [:group-by :age :sort-by :sd :salary])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [] [:age :name :sum :salary] [:group-by :age :name :sort-by :sum :salary])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:salary (g/< (g/lit 0) :salary)] [:age (g/< (g/lit 24) :age)]] [] [:sort-by :salary])
-                                        (dtj/print))
-                                    (-> data
-                                        (dtj/dataset)
-                                        (dtj/query [[:sum :salary (g/< (g/lit 0) (keyword "sum(salary)"))] [:age (g/< (g/lit 0) :age)]] [:name :age :salary :sum :salary :sd :salary] [:group-by :name :age :sort-by :sum :salary])
-                                        (dtj/print))))]
+                                     (dtj/dataset)
+                                     (dtj/query [[:salary (g/< (g/lit 300) :salary)] [:age (g/> (g/lit 20) :age)]] [])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:sum :salary (g/< (g/lit 1000) (keyword "sum(salary)"))]] [:age :sum :salary] [:group-by :age])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [] [:age :sum :salary :sd :salary] [:group-by :age :sort-by :sd :salary])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [] [:age :name :sum :salary] [:group-by :age :name :sort-by :sum :salary])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:salary (g/< (g/lit 0) :salary)] [:age (g/< (g/lit 24) :age)]] [] [:sort-by :salary])
+                                     (dtj/print))
+                                 (-> data
+                                     (dtj/dataset)
+                                     (dtj/query [[:sum :salary (g/< (g/lit 0) (keyword "sum(salary)"))] [:age (g/< (g/lit 0) :age)]] [:name :age :salary :sum :salary :sd :salary] [:group-by :name :age :sort-by :sum :salary])
+                                     (dtj/print))))]
     (is (check actual expected) actual)))


### PR DESCRIPTION
- Closes #51 

Details:
- Use `cljfmt` to standardize coding style
- Reimplement and optimize the `group-by` operation (and other related operations) of TMD and Tablecloth backends
- ...